### PR TITLE
Jcg/ada 40 company search backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ SENDGRID_API_KEY={the API key from passwords spreadsheet}
 ~~~~
 The Heroku info may expire at some point; just go get the info again if things stop working.
 
+## Developing with local Postgres instance
+If working on database-related features where testing on a local instance is necessary, change the DATABASE_URL in the acmw-db-app .env to your local database URL, and comment out the indicated line in acmw-db-app/postgres/pg-query.js. Do not commit pg-query.js with that line commented out.
+
 ## Usage
 To start the application locally, run ```npm run dev``` from the root directory.
 

--- a/acmw-db-app/pages/api/account/[pid].js
+++ b/acmw-db-app/pages/api/account/[pid].js
@@ -1,6 +1,6 @@
 import pgQuery from '../../../postgres/pg-query.js';
 
-// GET /api/account/verify
+// POST /api/account/verify
 // Check for matching email and password
 async function verify (email, password) {
     const data = await pgQuery(`SELECT email FROM account WHERE email = '${email}' AND password = crypt('${password}', password);`);
@@ -20,7 +20,11 @@ export default async (req, res) => {
     
             if(pid === 'verify') {
                 result = await verify(body.email, body.password);
+            } else {
+                throw("Invalid pid");
             }
+        } else {
+            throw("Invalid request type for account");
         }
         res.statusCode = 200;
     } catch(err) {

--- a/acmw-db-app/pages/api/company/[pid].js
+++ b/acmw-db-app/pages/api/company/[pid].js
@@ -1,0 +1,35 @@
+import pgQuery from '../../../postgres/pg-query.js';
+
+// GET /api/company/byString
+// Given a string check for potential matching companies
+async function companiesByString (input) {
+    const data = await pgQuery(`SELECT c.cname, c.id FROM company c WHERE LOWER(c.cname) LIKE LOWER('%${input}%')`);
+    return data.rows;
+}
+
+export default async (req, res) => {
+    const { 
+      query: { pid },
+    } = req
+
+    let result = {};
+
+    try {
+        if(req.method === 'GET'){
+            if(pid === 'byString') {
+                if(!req.query.input) throw ("Missing input query");
+                result = await companiesByString(req.query.input);
+            } else {
+                throw("Invalid pid");
+            }
+        } else {
+            throw("Invalid request type for company");
+        }
+        res.statusCode = 200;
+    } catch(err) {
+        res.statusCode = 500;
+        result.error = err;
+    } finally {
+        res.json(result);
+    }
+  }


### PR DESCRIPTION
Added API endpoint for searching companies given a string (case insensitive). For example, given "amazon", it returns the names and ids of "Amazon", "Amazon Web Services", "Amazon Robotics", and "Not Amazon as First Word". 

To test:

- Get local postgres instance if you don't already have one
- See the readme changes IN THIS PR (not master) for the other changes you have to make to work with a local DB
- Add companies to your local db
- npm run dev
- Hit the endpoint in the browser at localhost:3000/api/company/byString?input=<key> i.e.  localhost:3000/api/company/byString?input=amazon
- You should get company names and ids that go with the input you entered
- You can also test out the error handling by omitting an input param or incorrectly spelling "byString"