### PR TITLE
Average Meeting Attendance

### DIFF
--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -15,13 +15,15 @@ async function averageAttendance () {
       fall += (year - 1);
       spring += year;
     }
-    const data = await pgQuery(`SELECT AVG(COUNT) FROM
-                                ( SELECT COUNT(DISTINCT student_id)
-                                  FROM meeting_student
-                                  RIGHT JOIN meeting
-                                  ON meeting_student.meeting_id=meeting.id
-                                  WHERE (meeting.semester='${fall}' OR meeting.semester='${spring}')
-                                  GROUP BY meeting.id) as counts;`);
+    const data = await pgQuery(
+      `SELECT AVG(COUNT) FROM
+      ( SELECT COUNT(DISTINCT student_id)
+      FROM meeting_student
+      RIGHT JOIN meeting
+      ON meeting_student.meeting_id=meeting.id
+      WHERE (meeting.semester='${fall}' OR meeting.semester='${spring}')
+      GROUP BY meeting.id) as counts;`
+    );
     return data.rows[0]["avg"] ? data.rows[0]["avg"] : 0;
 }
 

--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -1,0 +1,38 @@
+import pgQuery from '../../../postgres/pg-query.js';
+
+// GET /api/meeting/averageAttendance
+async function averageAttendance () {
+    var attendees = 0;
+    const meetingIds = await pgQuery(`SELECT id FROM meeting`);
+    for (var i = 0; i < meetingIds.rows.length; i++) {
+        const data = await pgQuery(`SELECT COUNT (*) FROM meeting_student WHERE meeting_id=${meetingIds.rows[i]["id"]}`);
+        attendees += parseInt(data.rows[0]["count"], 10);
+    }
+    return attendees/meetingIds.rows.length;
+}
+
+export default async (req, res) => {
+    const {
+      query: { pid },
+    } = req
+
+    let result = {};
+
+    try {
+        if (req.method === 'GET'){
+            if (pid === 'averageAttendance') {
+                result = await averageAttendance();
+            } else {
+                throw("Invalid pid");
+            }
+        } else {
+            throw("Invalid request type for meeting");
+        }
+        res.statusCode = 200;
+    } catch(err) {
+        res.statusCode = 500;
+        result.error = err;
+    } finally {
+        res.json(result);
+    }
+  }

--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -5,7 +5,7 @@ async function averageAttendance () {
     const d = new Date();
     const year = d.getFullYear() - 2000;
     const month = d.getMonth();
-    var fall = "AU", spring = "SP";
+    let fall = "AU", spring = "SP";
     if (8 <= month <= 12) {
       // it's currrently fall semester
       fall += year;
@@ -16,14 +16,14 @@ async function averageAttendance () {
       spring += year;
     }
     const data = await pgQuery(`SELECT AVG(COUNT) FROM
-                                      ( SELECT COUNT(DISTINCT student_id)
-                                        FROM meeting_student
-                                        INNER JOIN meeting
-                                        ON meeting_student.meeting_id=meeting.id
-                                        AND (meeting.semester='${fall}' OR meeting.semester='${spring}')
-                                        GROUP BY meeting_student.meeting_id)
-                                      as counts;`);
-    return data.rows[0]["avg"];
+                                ( SELECT COUNT(DISTINCT student_id)
+                                  FROM meeting_student
+                                  RIGHT JOIN meeting
+                                  ON meeting_student.meeting_id=meeting.id
+                                  WHERE (meeting.semester='${fall}' OR meeting.semester='${spring}')
+                                GROUP BY meeting.id)
+                                as counts;`);
+    return data.rows[0]["avg"] ? data.rows[0]["avg"] : 0;
 }
 
 export default async (req, res) => {

--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -17,7 +17,7 @@ async function averageAttendance () {
     }
     const data = await pgQuery(
       `SELECT AVG(COUNT) FROM
-      ( SELECT COUNT(DISTINCT student_id)
+      ( SELECT COUNT(student_id)
       FROM meeting_student
       RIGHT JOIN meeting
       ON meeting_student.meeting_id=meeting.id

--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -21,8 +21,7 @@ async function averageAttendance () {
                                   RIGHT JOIN meeting
                                   ON meeting_student.meeting_id=meeting.id
                                   WHERE (meeting.semester='${fall}' OR meeting.semester='${spring}')
-                                GROUP BY meeting.id)
-                                as counts;`);
+                                  GROUP BY meeting.id) as counts;`);
     return data.rows[0]["avg"] ? data.rows[0]["avg"] : 0;
 }
 

--- a/acmw-db-app/postgres/pg-query.js
+++ b/acmw-db-app/postgres/pg-query.js
@@ -5,7 +5,7 @@ export default async (query) => {
     dotenv.config({ silent: process.env.NODE_ENV === 'production' });
     const dbConfig = {
         connectionString: process.env.DATABASE_URL,
-//        ssl: {rejectUnauthorized: false}  // Comment out this line if connecting to local DB
+        ssl: {rejectUnauthorized: false}  // Comment out this line if connecting to local DB
     }
     
     const client = new pg.Client(dbConfig);

--- a/acmw-db-app/postgres/pg-query.js
+++ b/acmw-db-app/postgres/pg-query.js
@@ -5,7 +5,7 @@ export default async (query) => {
     dotenv.config({ silent: process.env.NODE_ENV === 'production' });
     const dbConfig = {
         connectionString: process.env.DATABASE_URL,
-        ssl: {rejectUnauthorized: false}  // Comment out this line if connecting to local DB
+//        ssl: {rejectUnauthorized: false}  // Comment out this line if connecting to local DB
     }
     
     const client = new pg.Client(dbConfig);


### PR DESCRIPTION
I'm sure there's a better way to do this that uses the joined tables feature, but I just counted everything. To test:
1. Comment out this line `ssl: {rejectUnauthorized: false}  // Comment out this line if connecting to local DB` in `postgres/pg-query.js`
2. Add some student ids to the student table
3. Add some meeting ids to the meeting table
4. Add student ids and meeting ids to the meeting_student table (beware that you cannot add ids that do not exist in the previous two tables)
5. Run `npm run dev`
6. Go to `http://localhost:3000/api/meeting/averageAttendance`