### PR TITLE
Jcg/ada 54 add account backend

### DIFF
--- a/acmw-db-app/pages/api/account/[pid].js
+++ b/acmw-db-app/pages/api/account/[pid].js
@@ -12,7 +12,6 @@ async function verify (email, password) {
 async function create (email, password, student_id) {
     const data = await pgQuery(`INSERT INTO account (email, password, student_id) 
         VALUES ('${email}', crypt('${password}', gen_salt('md5')), ${student_id ? `'${student_id}'`: null});`); // Ensure that if student_id is undefined, empty, etc. it gets inserted as null
-    console.log(data)
     return data;
 }
 

--- a/acmw-db-app/pages/api/account/[pid].js
+++ b/acmw-db-app/pages/api/account/[pid].js
@@ -1,10 +1,19 @@
 import pgQuery from '../../../postgres/pg-query.js';
 
-// GET /api/account/verify
+// POST /api/account/verify
 // Check for matching email and password
 async function verify (email, password) {
     const data = await pgQuery(`SELECT email FROM account WHERE email = '${email}' AND password = crypt('${password}', password);`);
     return data.rows;
+}
+
+// POST /api/account/create
+// Create an account: email = new user's email address, password = unencrypted new password, student_id may be null
+async function create (email, password, student_id) {
+    const data = await pgQuery(`INSERT INTO account (email, password, student_id) 
+        VALUES ('${email}', crypt('${password}', gen_salt('md5')), ${student_id ? `'${student_id}'`: null});`); // Ensure that if student_id is undefined, empty, etc. it gets inserted as null
+    console.log(data)
+    return data;
 }
 
 export default async (req, res) => {
@@ -17,9 +26,16 @@ export default async (req, res) => {
     try {
         if(req.method === 'POST'){
             const body = JSON.parse(req.body);
-    
-            if(pid === 'verify') {
-                result = await verify(body.email, body.password);
+            switch(pid) {
+                case 'verify':
+                    result = await verify(body.email, body.password);
+                    break;
+                case 'create':
+                    console.log(body.student_id)
+                    result = await create(body.email, body.password, body.student_id);
+                    break;
+                default:
+                    throw("Invalid pid");
             }
         }
         res.statusCode = 200;


### PR DESCRIPTION
This is an API endpoint for creating a new user account (this is not the same as creating a new student member; accounts are only for exec and GHC recipients for now). To test:

1. Have a local instance of the database set up (see readme)
2. npm run dev
3. Using postman (or similar app), hit the endpoint with a POST request at http://localhost:3000/api/account/create with a body that has "email" and "password" fields. I can't attach a picture here but DM on slack if needed and I will send what I mean
4. Go to the signin page in the app and log in with the email and password you made, if this was successful you will NOT see an error. 
5. Insert a student into your student table via psql or whatever thing you use to talk to your db: INSERT INTO student (fname, lname) VALUES ('brutus', 'buckeye');
6. Make sure brutus is there and get his id from the table: SELECT * FROM student;
7. Repeat steps 3 and 4 but this time add "student_id" with the value you just got from step 6 to the request body, and **change the email address since those must be unique** .
8. as long as you don't have a bad login it should be fine but you can also check that the accounts were made with SELECT * FROM account; 