### PR TITLE
fixed email regex in signin

### DIFF
--- a/acmw-db-app/pages/signin.js
+++ b/acmw-db-app/pages/signin.js
@@ -117,7 +117,9 @@ const SignInButton = (props) => {
 
   const validateSignIn = async () => {
     // Check that email and password match
-    const regex = new RegExp("[a-z]+\.[1-9]([0-9]+)?@(buckeyemail\.)?osu\.edu"); //matches letters . number w/o leading 0 @ (buckeyemail.) osu . edu
+    
+    //matches case insensitive letters. number w/o leading 0 @ (buckeyemail.) osu . edu
+    const regex = new RegExp(/^([a-z]+\.[1-9]([0-9]+)?@(buckeyemail\.)?osu\.edu)$/i);
     if (props.email && props.password && regex.test(props.email)) {
       const requestOptions = {
         method: 'POST',


### PR DESCRIPTION
1. `npm run dev`
2. `http://localhost:3000/signin`
YOU HOPEFULLY CAN'T TYPE NON LETTERS BEFORE OR ANYTHING AFTER NOW >;DDD
also case insensitive bc that's how emails are (hmmmm although we might wanna make stuff lowercase in the database)