### PR TITLE
ADA-35 created sponsorship table

### DIFF
--- a/migrations/SQL/0007_create-sponsorship.sql
+++ b/migrations/SQL/0007_create-sponsorship.sql
@@ -1,0 +1,18 @@
+-- DROP TYPE IF EXISTS tier;
+-- DROP TYPE IF EXISTS sponsorship_status;
+-- CREATE TYPE IF NOT EXISTS tier AS ENUM ('gold', 'silver', 'purple');
+-- CREATE TYPE IF NOT EXISTS sponsorship_status AS ENUM ('pending','sent','received');
+
+
+CREATE TABLE IF NOT EXISTS sponsorship (
+    id SERIAL PRIMARY KEY, 
+    academic_year INT, 
+    dollars MONEY, 
+    purple_tier BOOLEAN,
+    silver_tier BOOLEAN,
+    gold_tier BOOLEAN,
+    -- tier_level tier, 
+    -- dollars_status sponsorship_status, 
+    dollars_status VARCHAR,
+    company_id INT REFERENCES company(id) ON UPDATE CASCADE ON DELETE CASCADE
+    );

--- a/migrations/SQL/0007_create-sponsorship.sql
+++ b/migrations/SQL/0007_create-sponsorship.sql
@@ -1,18 +1,9 @@
--- DROP TYPE IF EXISTS tier;
--- DROP TYPE IF EXISTS sponsorship_status;
--- CREATE TYPE IF NOT EXISTS tier AS ENUM ('gold', 'silver', 'purple');
--- CREATE TYPE IF NOT EXISTS sponsorship_status AS ENUM ('pending','sent','received');
-
 
 CREATE TABLE IF NOT EXISTS sponsorship (
     id SERIAL PRIMARY KEY, 
     academic_year INT, 
     dollars MONEY, 
-    purple_tier BOOLEAN,
-    silver_tier BOOLEAN,
-    gold_tier BOOLEAN,
-    -- tier_level tier, 
-    -- dollars_status sponsorship_status, 
+    tier VARCHAR,
     dollars_status VARCHAR,
     company_id INT REFERENCES company(id) ON UPDATE CASCADE ON DELETE CASCADE
     );


### PR DESCRIPTION
I wanted to use ENUMs but was getting a depreciation warning lol - definitely open to other ideas on how to handle tires/status if you want to check out the comments

how to test:
`git pull`
`git checkout ADA-35`
on the root directory `npm run migrate`
and check out the sponsorship table successfully shows up in your postgresql local or pdadmin local

NOTE: I know this is named the same as @jgeorge37 recent database PR but we figure this might be easier to merge first 