### PR TITLE
ADA-128 add add_to_newsletter column to meeting_student

### DIFF
--- a/migrations/SQL/0014_add-news-col.sql
+++ b/migrations/SQL/0014_add-news-col.sql
@@ -1,0 +1,2 @@
+ALTER TABLE meeting_student
+ADD COLUMN IF NOT EXISTS add_to_newsletter BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
To test, check that the new add_to_newletter column is in the meeting student table in Dev. You can use pgadmin as explained in the README, or if you have the heroku CLI installed (would recommend; this is my preferred method!), go to [Heroku](https://data.heroku.com/datastores/1eca8280-1bfa-4ec8-a382-341bb8b70672#administration) and copy the Heroku CLI line, then paste into terminal, then do `SELECT * FROM meeting_student;`.