### PR TITLE
ADA-135 API endpoint to delete a meeting

### DIFF
--- a/acmw-db-app/pages/api/meeting/[pid].js
+++ b/acmw-db-app/pages/api/meeting/[pid].js
@@ -88,6 +88,23 @@ async function create(meeting_name, meeting_date, semester, company_id) {
     return data;  
 }
 
+// POST /api/meeting/delete
+// delete a meeting given meeting_id
+async function delete_(id) {
+    const data = await pgQuery(`SELECT meeting_name, semester FROM meeting WHERE id=${id};`);
+    if(data.rowCount === 0) throw(`Meeting with id ${id} not found.`);
+    
+    const meetingInfo = data.rows[0].meeting_name + " - " + data.rows[0].semester;
+    // delete attendance records
+    await pgQuery(`DELETE FROM meeting_student WHERE meeting_id=${id};`); 
+    // delete company partnership
+    await pgQuery(`DELETE FROM meeting_company WHERE meeting_id=${id};`);
+    // delete meeting
+    await pgQuery(`DELETE FROM meeting WHERE id=${id};`);
+    
+    return "Successfully deleted " + meetingInfo;
+}
+
 export default async (req, res) => {
     const {
       query: { pid },
@@ -127,6 +144,10 @@ export default async (req, res) => {
                     if (!body.meeting_date) throw ("Must provide meeting date!");
                     if (!body.semester) throw ("Must provide semester!");
                     result = await create(body.meeting_name, body.meeting_date, body.semester, body.company_id);
+                    break;
+                case 'delete':
+                    if(!body.meeting_id) throw("Must provide a meeting_id");
+                    result = await delete_(body.meeting_id);
                     break;
                 default:
                     throw("Invalid pid");


### PR DESCRIPTION
In dev create a meeting and partner it with a company.
In the database, find the meeting id.

With postman or the API tester of your choice, send a POST request to https://dev-ada.herokuapp.com/api/meeting/delete with a body containing meeting_id 

Check the database again for the meeting - it should be gone and the company association should be gone from meeting_company.