### PR TITLE
Ada 140 migration

### DIFF
--- a/migrations/SQL/0015_auth-tok-and-uniq-contact.sql
+++ b/migrations/SQL/0015_auth-tok-and-uniq-contact.sql
@@ -1,0 +1,14 @@
+DO $$ 
+BEGIN 
+IF EXISTS
+    (SELECT * FROM information_schema.columns WHERE table_name='account' and column_name='token_expire_time') 
+THEN ALTER TABLE public.account RENAME COLUMN token_expire_time TO reset_expire_time; 
+END IF; 
+END $$;
+
+ALTER TABLE account 
+ADD COLUMN IF NOT EXISTS auth_token VARCHAR,
+ADD COLUMN IF NOT EXISTS auth_expire_time TIMESTAMP;
+
+ALTER TABLE contact
+ADD UNIQUE(email);


### PR DESCRIPTION
Migration only for ADA-140 - making a separate branch to make sure migration numbers don't get weird. This adds auth_token and auth_expire_time to the account table, which are used to determine if a user is who they say they are, and if a user is allowed to access certain pages or API endpoints. 

Also renames the column token_expire_time to reset_expire_time for clarity

And I made the email in the contact table unique since I noticed duplicates were allowed which we do not want