### PR TITLE
ADA-140 add auth related columns to account

### DIFF
--- a/migrations/SQL/0015_auth-tok-and-uniq-contact.sql
+++ b/migrations/SQL/0015_auth-tok-and-uniq-contact.sql
@@ -1,0 +1,14 @@
+DO $$ 
+BEGIN 
+IF EXISTS
+    (SELECT * FROM information_schema.columns WHERE table_name='account' and column_name='token_expire_time') 
+THEN ALTER TABLE public.account RENAME COLUMN token_expire_time TO reset_expire_time; 
+END IF; 
+END $$;
+
+ALTER TABLE account 
+ADD COLUMN IF NOT EXISTS auth_token VARCHAR,
+ADD COLUMN IF NOT EXISTS auth_expire_time TIMESTAMP;
+
+ALTER TABLE contact
+ADD UNIQUE(email);


### PR DESCRIPTION
Get the dev database credentials from Heroku and throw that into terminal or go to pgAdmin or whatever you do to look at the dev database. See that there are now two new columns in the account table, auth_token and auth_expire_time