### PR TITLE
ADA-149 Silence duplicate attendance error

### DIFF
--- a/pages/api/attendance/[pid].js
+++ b/pages/api/attendance/[pid].js
@@ -42,14 +42,13 @@ async function record (event_code, f_name, l_name_dot_num, year_level, list_serv
     `);
 
     try {
-        const data = await pgQuery(`
+        await pgQuery(`
             INSERT INTO meeting_student (meeting_id, student_id, add_to_newsletter) VALUES (${meetingId}, ${curr_student_id.rows[0].id}, ${list_serv})
         ;`);
-        return data;
     } catch(err) {
-        if(err.code === '23505') throw ("Attendance already recorded for this meeting");
-        throw (err);
+        if(err.code !== '23505') throw (err);  // silence duplication attendance error 
     }
+    return {message: "success"}
 }
 
 export default async (req, res) => {


### PR DESCRIPTION
Create a meeting. Then submit attendance for that meeting for the same student twice - no error should be given. Their attendance will not be saved twice but if they needed to update something (like they spelled their name wrong) it will go through without an error showing.